### PR TITLE
Fix Rd parsing issues (don't escape '&')

### DIFF
--- a/man/mixmeta-package.Rd
+++ b/man/mixmeta-package.Rd
@@ -112,7 +112,7 @@ Lindstrom MJ and Bates DM (1988). Newton-Raphson and EM algorithms for linear mi
 
 Goldstein H (1986). Multilevel mixed linear model analysis using iterative generalized least squares. \emph{Biometrika}. \bold{73}(1):43--56.
 
-Goldstein H (1992). Efficient computational procedures for the estimation of parameters in multilevel models based on iterative generalized least squares. \emph{Computational Statistics \& Data Analysis}. \bold{13}(1):63--71.
+Goldstein H (1992). Efficient computational procedures for the estimation of parameters in multilevel models based on iterative generalized least squares. \emph{Computational Statistics & Data Analysis}. \bold{13}(1):63--71.
 
 Stram DO (1996). Meta-analysis of published data using a linear mixed-effects model. \emph{Biometrics}. \bold{52}(2):536--544.
 

--- a/man/mixmeta.ml.Rd
+++ b/man/mixmeta.ml.Rd
@@ -53,7 +53,7 @@ Lindstrom MJ and Bates DM (1988). Newton-Raphson and EM algorithms for linear mi
 
 Goldstein H (1986). Multilevel mixed linear model analysis using iterative generalized least squares. \emph{Biometrika}. \bold{73}(1):43.
 
-Goldstein H (1992). Efficient computational procedures for the estimation of parameters in multilevel models based on iterative generalized least squares. \emph{Computational Statistics \& Data Analysis}. \bold{13}(1):63--71.
+Goldstein H (1992). Efficient computational procedures for the estimation of parameters in multilevel models based on iterative generalized least squares. \emph{Computational Statistics & Data Analysis}. \bold{13}(1):63--71.
 }
 
 \author{Antonio Gasparrini <\email{antonio.gasparrini@lshtm.ac.uk}> and Francesco Sera <\email{francesco.sera@lshtm.ac.uk}>}

--- a/man/ml.igls.Rd
+++ b/man/ml.igls.Rd
@@ -59,7 +59,7 @@ The functions \code{ml.igls} and \code{reml.rigls} return an intermediate list o
 \references{
 Sera F, Armstrong B, Blangiardo M, Gasparrini A (2019). An extended mixed-effects framework for meta-analysis.\emph{Statistics in Medicine}. 2019;38(29):5429-5444. [Freely available \href{http://www.ag-myresearch.com/2019_sera_statmed.html}{\bold{here}}].
 
-Goldstein H (1992). Efficient computational procedures for the estimation of parameters in multilevel models based on iterative generalized least squares. \emph{Computational Statistics \& Data Analysis}. \bold{13}(1):63--71.
+Goldstein H (1992). Efficient computational procedures for the estimation of parameters in multilevel models based on iterative generalized least squares. \emph{Computational Statistics & Data Analysis}. \bold{13}(1):63--71.
 
 Goldstein H (1986). Multilevel mixed linear model analysis using iterative generalized least squares. \emph{Biometrika}. \bold{73}(1):43--56.
 


### PR DESCRIPTION
I wrote this patch for internal reasons, sharing it back upstream to save duplicate effort.

An LLM wrote it, but it's a trivial fix anyway.